### PR TITLE
Remove debug stdout  println statements

### DIFF
--- a/src/main/scala/util/retry/blocking/Retry.scala
+++ b/src/main/scala/util/retry/blocking/Retry.scala
@@ -111,13 +111,10 @@ object Retry {
   def apply[T](fn: => T)(implicit strategy: RetryStrategy): Retry[T] =
     Try(fn) match {
       case x: scala.util.Success [T] =>
-        println("Computation succeeded.")
         Success(x.value)
       case _ if strategy.shouldRetry() =>
-        println("Computation failed. Retrying...")
         apply(fn)(strategy.update())
       case f: scala.util.Failure [T] =>
-        println("Computation failed. Giving up...")
         Failure(f.exception)
     }
 }


### PR DESCRIPTION
Was reviewing this library and noticed these debug outputs that would cause me grief in production. Thanks!